### PR TITLE
Don't Auto-Retry

### DIFF
--- a/spec/unit/contextio/api_spec.rb
+++ b/spec/unit/contextio/api_spec.rb
@@ -119,6 +119,22 @@ describe ContextIO::API do
   describe "#request" do
     subject { ContextIO::API.new(nil, nil).request(:get, 'test') }
 
+    context "with a timeout response" do
+      before do
+        WebMock.stub_request(
+          :get,
+          'https://api.context.io/2.0/test'
+        ).to_timeout.then.to_return(
+          status: 200,
+          body: JSON.dump('yep' => 'noap'),
+        )
+      end
+
+      it "parses the JSON response" do
+        expect { ContextIO::API.new(nil, nil).request(:get, 'test') }.to raise_error(Faraday::Error::TimeoutError)
+      end
+    end
+
     context "with a good response" do
       before do
         WebMock.stub_request(


### PR DESCRIPTION
After hearing that some people were getting nonce-reused error, and seeing in logs that people were making more than one request with a given nonce, I tried to write a test to see whether the gem was auto-retrying requests without regenerating the nonce. I intended for the gem *not* to automatically retry requests, leaving it up to the developer how and whether to retry something.

The test in this Pull Request seems to indicate that Faraday doesn't automatically retry timed out requests. This test passes as is, but if you explicitly add the retry middleware to the connection object, it then fails.

Maybe I'm missing something, though. If the gem is doing weird stuff with retrying, I'd like to have a test showing it, so we can track it down and kill it with fire.