### PR TITLE
Faraday 9.0

### DIFF
--- a/contextio.gemspec
+++ b/contextio.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'faraday', '~> 0.8.0'
+  gem.add_dependency 'faraday', ['>= 0.8.0', '< 0.10.0']
   gem.add_dependency 'faraday_middleware', '~> 0.9.0'
   gem.add_dependency 'simple_oauth', '~> 0.2.0'
 


### PR DESCRIPTION
Is it possible to support Faraday 9.0.  Have other gems that depend on the newer version.