### PR TITLE
made message->thread method public

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Moved `ContextIO::Message#thread` from private to public, and also changed the
+  method to return json data instead of creating a `ContextIO::Thread` object. - Eric Pinzur
 * Add 'references' to lazy_attributes in message.rb - Dylan Stamat
 
 ## 1.7.2

--- a/lib/contextio/message.rb
+++ b/lib/contextio/message.rb
@@ -92,13 +92,10 @@ class ContextIO
       api.request(:delete, resource_url)['success']
     end
 
-    private
-
-    # The API doesn't return enough information to build a resource_url for this
-    # resource, or the resource_url its self, making this problematic. Marking
-    # this private until something is sorted on that front.
+    # Returns a list of all messages and a list of all email_message_ids in the same thread as this message.
+    # Note that it does not create a Thread object or a MessageCollection object in its current state.
     def thread
-      ContextIO::Thread.new(api, api.request(:get, "#{resource_url}/thread").merge(account: account))
+      api.request(:get, "#{resource_url}/thread")
     end
   end
 end

--- a/spec/unit/contextio/message_spec.rb
+++ b/spec/unit/contextio/message_spec.rb
@@ -35,4 +35,19 @@ describe ContextIO::Message do
       subject.set_flags({:seen => true})
     end
   end
+
+  describe "#thread" do
+    before do
+      allow(api).to receive(:request).and_return({'email_message_ids' => [], 'person_info' => {}, 'messages' => []})
+    end
+
+    it "gets to the thread method api" do
+      expect(api).to receive(:request).with(
+        :get,
+        'resource/url/thread'
+      )
+
+      subject.thread
+    end
+  end
 end


### PR DESCRIPTION
Also update the method to NOT create a Thread object, as the context.io API does not currently return enough information from this endpoint to create an object of this type.