### PR TITLE
Changes Folder class to allow lazy access

### DIFF
--- a/lib/contextio/api/url_builder.rb
+++ b/lib/contextio/api/url_builder.rb
@@ -92,6 +92,10 @@ class ContextIO
       register_url ContextIO::FolderCollection do |folders|
         "accounts/#{folders.source.account.id}/sources/#{folders.source.label}/folders"
       end
+      
+      register_url ContextIO::Folder do |folder|
+        "accounts/#{folder.source.account.id}/sources/#{folder.source.label}/folders/#{folder.name}"
+      end
 
       register_url ContextIO::Message do |message|
         "accounts/#{message.account.id}/messages/#{message.message_id}"

--- a/lib/contextio/folder.rb
+++ b/lib/contextio/folder.rb
@@ -2,9 +2,11 @@ require 'contextio/api/association_helpers'
 
 class ContextIO
   class Folder
-    def self.association_name
-      :folder
-    end
+    include ContextIO::API::Resource
+
+    self.primary_key = :name
+    self.association_name = :folder
+
     ContextIO::API::AssociationHelpers.register_resource(self, :folder)
 
     # (see ContextIO#api)

--- a/lib/contextio/folder.rb
+++ b/lib/contextio/folder.rb
@@ -10,7 +10,7 @@ class ContextIO
     ContextIO::API::AssociationHelpers.register_resource(self, :folder)
 
     # (see ContextIO#api)
-    attr_reader :api, :source, :name, :attributes, :delim, :nb_messages,
+    lazy_attributes :api, :source, :name, :attributes, :delim, :nb_messages,
                 :uidvalidity, :nb_unseen_messages
     private :attributes
 


### PR DESCRIPTION
This should fix the issue #65 and allow lazy access to any folder by name like so:
context_io.accounts[account_token].sources[0].folders[folder_name]