### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 * Lazy Folder access, and allow indexing folder collection by name
 
-##2.0.0
+## 2.0.0
 
 * Limit Faraday to no retries on requests, update version of faraday -Bonnie Mattson
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
